### PR TITLE
silence error about invalid version

### DIFF
--- a/static/package.json
+++ b/static/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schema-interface",
-  "version": "0.6",
+  "version": "0.6.0",
   "description": "Schema Curation Interface",
   "private": true,
   "scripts": {


### PR DESCRIPTION
npm currently complains about the version because it is not semver compliant.  I added a .0 at the end to resolve that.